### PR TITLE
Fixed the slider CPU use crash.

### DIFF
--- a/src/asyncworker.py
+++ b/src/asyncworker.py
@@ -6,9 +6,11 @@ class AsyncWorker(Thread):
     """
     Tiny class to queue up tasks to run on a worker thread.
     """
-    def __init__(self):
+    def __init__(self, name=""):
         Thread.__init__(self)
         self.queue = Queue.Queue(0)
+        self.name = name
+        self.finished = False
 
     def add_task(self, task, args=()):
         self.queue.put((task, args))
@@ -21,3 +23,4 @@ class AsyncWorker(Thread):
             except Exception:
                 print "In worker thread...."
                 print traceback.format_exc()
+        self.finished = True


### PR DESCRIPTION
The issue was a thread was being spawned after GTK sent
the signal to indicate the slider was no longer in use.
This caused a thread to sit in an infinite loop and
consume resources.

The fix was to track the use of threads by giving them
optional names.  This list of active threads is only kept
up to date in the slider method, but any method could also
keep it up to date by invoking _prune_active_threads().
