### PR TITLE
Fixed border flashing old borders.

### DIFF
--- a/src/photos_image_widget.py
+++ b/src/photos_image_widget.py
@@ -56,7 +56,6 @@ class PhotosImageWidget(Clutter.Actor):
         self.set_property('ratio', float(width)/height)
 
     def replace_border_image(self, data, width, height):
-        self._border_image.show()
         Gdk.threads_add_idle(
             GLib.PRIORITY_DEFAULT_IDLE,
             lambda dummy: self._replace_border_image_callback(data, width, height),


### PR DESCRIPTION
The issue was that older borders were being
displayed after another, different border was selected.  This was
due to an erroneous call to show() before the callback was
invoked.  With the call removed, this issue has been resolved.
