### PR TITLE
Removed init import of endless_photos

### DIFF
--- a/endless-os-photos
+++ b/endless-os-photos
@@ -2,7 +2,7 @@
 
 import sys
 sys.path.append('/usr/share/endless-os-photos')
-from src import EndlessPhotos
+from src.endless_photos import EndlessPhotos
 from gi.repository import GtkClutter, GLib, Gdk
 
 app = EndlessPhotos()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,0 @@
-from .endless_photos import EndlessPhotos
-__all__ = ['EndlessPhotos']


### PR DESCRIPTION
This will hopefully fix the jenkins build and keep us from having
a build dependency on the SDK
