### PR TITLE
Quick fix for oversized topbar buttons

### DIFF
--- a/data/endless_photos.css
+++ b/data/endless_photos.css
@@ -14,6 +14,11 @@
     text-shadow: none;
 }
 
+/* TODO: hack fix until we move from adwaita to our proper SDK theme*/
+.top-bar * {
+  -GtkWidget-focus-padding: 0;
+}
+
 GtkButton {
     transition:background-image 200ms ease-in-out;
 }


### PR DESCRIPTION
Just overriding some default padding in the Adwaita theme. Eventaully
we will be using our own SDK theme and this fix can go away.
