### PR TITLE
Another slider threading fix -Sebastian and Matt

### DIFF
--- a/src/photos_category_toolbars.py
+++ b/src/photos_category_toolbars.py
@@ -145,7 +145,6 @@ class AdjustmentToolbar(CategoryToolbar):
         self._brightness_slider = Gtk.HScale(adjustment=brightness_adjust, draw_value=False)
         self._brightness_slider.connect(
             "value-changed", lambda adjust: self._presenter.on_brightness_change(adjust.get_value()))
-        self._brightness_slider.connect('button-release-event', lambda w, e: self._presenter.on_slider_release())
         self._brightness_slider.connect('key-press-event', lambda w, e: True)
         self._vbox.pack_start(self._brightness_label, False, False, 0)
         self._vbox.pack_start(self._brightness_slider, False, False, 0)
@@ -156,7 +155,6 @@ class AdjustmentToolbar(CategoryToolbar):
         self._contrast_slider = Gtk.HScale(adjustment=contrast_adjust, draw_value=False)
         self._contrast_slider.connect(
             "value-changed", lambda adjust: self._presenter.on_contrast_change(adjust.get_value()))
-        self._contrast_slider.connect('button-release-event', lambda w, e: self._presenter.on_slider_release())
         self._contrast_slider.connect('key-press-event', lambda w, e: True)
         self._vbox.pack_start(self._contrast_label, False, False, 0)
         self._vbox.pack_start(self._contrast_slider, False, False, 0)
@@ -167,7 +165,6 @@ class AdjustmentToolbar(CategoryToolbar):
         self._saturation_slider = Gtk.HScale(adjustment=saturation_adjust, draw_value=False)
         self._saturation_slider.connect(
             "value-changed", lambda adjust: self._presenter.on_saturation_change(adjust.get_value()))
-        self._saturation_slider.connect('button-release-event', lambda w, e: self._presenter.on_slider_release())
         self._saturation_slider.connect('key-press-event', lambda w, e: True)
         self._vbox.pack_start(self._saturation_label, False, False, 0)
         self._vbox.pack_start(self._saturation_slider, False, False, 0)


### PR DESCRIPTION
Now instead of listening to mouse up and down on the slider. We
just kill the "sliding thread" after it has been inactive for 200ms
