### PR TITLE
Resurrected prompt for save

### DIFF
--- a/src/photos_presenter.py
+++ b/src/photos_presenter.py
@@ -160,11 +160,6 @@ class PhotosPresenter(object):
 
         self._view.close_window()
 
-    def on_minimize(self):
-        if self._locked:
-            return
-        self._view.minimize_window()
-
     def on_open(self):
         if self._locked:
             return

--- a/src/photos_window.py
+++ b/src/photos_window.py
@@ -70,6 +70,11 @@ class PhotosWindow(Endless.Window):
         pm.add(self._fullscreen_attach)
 
         self.connect('key_press_event', self._on_keypress)
+        self.connect('delete-event', self._on_delete)
+
+    def _on_delete(self, widget, event):
+        self._presenter.on_close()
+        return True
 
     def _on_keypress(self, widget, event):
         # We only call set_fullscreen to false if we are on the fullscreen page


### PR DESCRIPTION
By listening to the delete-event signal generated in the eos-window
