### PR TITLE
Fixed the black borders from being drawn on photos

### DIFF
--- a/src/image_processing/distortions.py
+++ b/src/image_processing/distortions.py
@@ -58,27 +58,27 @@ class Distortion:
         if distort_name == "SWIRL":
             radius = max(shape[0], shape[1]) / 2
             result = swirl(self._image_array, center=(shape[1]/2, shape[0]/2), strength=5, 
-                radius=radius, order=1)
+                radius=radius, order=1, mode='nearest')
         elif distort_name == "FISH EYE LIGHT":
             warp_args['radius_func'] = lambda radius_d: self.fish_eye(0.3, radius_d)
             warp_args['zoom_factor'] = 1.6
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args)
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
         elif distort_name == "FISH EYE HEAVY":
             warp_args['radius_func'] = lambda radius_d: self.fish_eye(0.6, radius_d)
             warp_args['zoom_factor'] = 2.2
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args)
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
         elif distort_name == "BULGE":
             warp_args['radius_func'] = lambda radius_d: self.bulge(radius_d)
             warp_args['zoom_factor'] = 1.45
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args)
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
         elif distort_name == "PINCH LIGHT":
             warp_args['radius_func'] = lambda radius_d: self.pinch(0.8, radius_d)
             warp_args['zoom_factor'] = 1
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args)
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
         elif distort_name == "PINCH HEAVY":
             warp_args['radius_func'] = lambda radius_d: self.pinch(0.5, radius_d)
             warp_args['zoom_factor'] = 1
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args)
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
         else:
             result = self._image_array
 


### PR DESCRIPTION
Added the 'nearest neighbor' mode to all skimage distortions
(i.e. calls to 'warp' and 'swirl'). This causes the distortions
to not set unmapped pixels to black by default

[endlessm/eos-photos#132]
