### PR TITLE
Save images to Pictures dir, sets background

### DIFF
--- a/data/endless_photos.css
+++ b/data/endless_photos.css
@@ -181,6 +181,7 @@ GtkLabel {
 }
 
 #save-button,
+#wallpaper-button,
 #share-button {
     background-color: transparent;
     background-image: none;
@@ -189,6 +190,7 @@ GtkLabel {
 }
 
 #save-button GtkLabel,
+#wallpaper-button GtkLabel,
 #share-button GtkLabel {
     font-size: 12px;
     text-shadow: 0px -1px 1px rgba(0,0,0,0.5);
@@ -196,13 +198,27 @@ GtkLabel {
 }
 
 #save-button GtkLabel:hover,
+#wallpaper-button GtkLabel:hover,
 #share-button GtkLabel:hover {
     color: #a1a1a1;
 }
 
 #save-button GtkLabel:active,
+#wallpaper-button GtkLabel:active,
 #share-button GtkLabel:active {
     color: #555555;
+}
+
+#wallpaper-button .image-frame {
+    background-image: url("../images/expand-image_normal.png");
+}
+
+#wallpaper-button .image-frame:hover {
+    background-image: url("../images/expand-image_hover.png");
+}
+
+#wallpaper-button .image-frame:active {
+    background-image: url("../images/expand-image_down.png");
 }
 
 #save-button .image-frame {

--- a/src/photos_right_toolbar.py
+++ b/src/photos_right_toolbar.py
@@ -26,6 +26,14 @@ class PhotosRightToolbar(Gtk.Alignment):
             vertical=True)
         self._share_button.connect('clicked', lambda w: self._presenter.on_share())
 
+        self._bg_button = ImageTextButton(
+            image_size_x=ImageTextButton.SIZE_MEDIUM,
+            image_size_y=ImageTextButton.SIZE_MEDIUM,
+            label=_("BACKGROUND"),
+            name="wallpaper-button",
+            vertical=True)
+        self._bg_button.connect('clicked', lambda w: self._presenter.on_set_background())
+
         # self._email_button = ImageTextButton(
         #     normal_path=images_path + "email_normal.png",
         #     hover_path=images_path + "email_hover.png",
@@ -38,6 +46,7 @@ class PhotosRightToolbar(Gtk.Alignment):
         self._button_box = Gtk.VBox(homogeneous=False, spacing=20)
         self._button_box.pack_start(self._save_button, expand=False, fill=False, padding=0)
         self._button_box.pack_start(self._share_button, expand=False, fill=False, padding=0)
+        self._button_box.pack_start(self._bg_button, expand=False, fill=False, padding=0)
         # self._button_box.pack_start(self._email_button, expand=False, fill=False, padding=0)
 
         self.add(self._button_box)


### PR DESCRIPTION
Defaults to a zoomed background of the image, saves the images
as {file name}_background.{filetype}, and overwrites existing
background images. Note that there is a known issue in older versions
of GNOME shell where the background may not change, but it is
supposedly fixed in later versions

UI uses a mock image and placement until design provides another

[endlessm/eos-photos#127]
