### PR TITLE
Added a thumbnail of selected image in open dialog

### DIFF
--- a/src/photos_view.py
+++ b/src/photos_view.py
@@ -6,6 +6,7 @@ from photos_right_toolbar import PhotosRightToolbar
 from photos_category_toolbars import AdjustmentToolbar, BorderToolbar, FilterToolbar, DistortToolbar, BlurToolbar
 from photos_window import PhotosWindow
 from photos_image_container import ImageContainer
+from widgets.preview_file_chooser_dialog import PreviewFileChooserDialog
 
 
 class PhotosView(object):
@@ -106,9 +107,10 @@ class PhotosView(object):
 
     def show_open_dialog(self, starting_dir=None):
         # Opens a dialog window where the user can choose an image file
-        dialog = Gtk.FileChooserDialog(
-            _("Open Image"), self.get_window(),
-            Gtk.FileChooserAction.OPEN)
+        dialog = PreviewFileChooserDialog(
+            title=_("Open Image"),
+            parent=self.get_window(),
+            action=Gtk.FileChooserAction.OPEN)
 
         if starting_dir != None:
             dialog.set_current_folder(starting_dir)

--- a/src/widgets/preview_file_chooser_dialog.py
+++ b/src/widgets/preview_file_chooser_dialog.py
@@ -1,0 +1,32 @@
+import os
+from gi.repository import Gtk, Gdk, GdkPixbuf
+
+
+class PreviewFileChooserDialog(Gtk.FileChooserDialog):
+    PREVIEW_MAX_SIZE = 128
+    def __init__(self, **kw):
+        super(PreviewFileChooserDialog, self).__init__(**kw)
+
+        self._preview = Gtk.Image()
+        # Don't let preview size down horizontally for skinny images, cause
+        # that looks distracting
+        self._preview.set_size_request(PreviewFileChooserDialog.PREVIEW_MAX_SIZE, -1)
+        self.set_preview_widget(self._preview)
+        self.set_use_preview_label(False)
+        self.connect("update-preview", self.update_preview_cb)
+
+    def update_preview_cb(self, file_chooser):
+        filename = self.get_preview_filename()
+        if filename is None or os.path.isdir(filename):
+            self.set_preview_widget_active(False)
+            return
+        try:
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(filename,
+                PreviewFileChooserDialog.PREVIEW_MAX_SIZE,
+                PreviewFileChooserDialog.PREVIEW_MAX_SIZE)
+            self._preview.set_from_pixbuf(pixbuf)
+        except Exception as e:
+            print e
+            self.set_preview_widget_active(False)
+            return
+        self.set_preview_widget_active(True)


### PR DESCRIPTION
Adapted from will's code from a spike. Loads a thumbnail with max dimensions
of 128x128 and adds that to the left of the file chooser dialog with the
preview widget property
#164
