### PR TITLE
Border image is now resized to cropped image size

### DIFF
--- a/src/photos_model.py
+++ b/src/photos_model.py
@@ -451,7 +451,7 @@ class PhotosModel(object):
         filename = self._border_dict[self._border]
         if filename is not None:
             self._border_image = Image.open(self._borders_path + filename).resize(
-                self._source_image.size, Image.BILINEAR)
+                self._adjusted_image.size, Image.BILINEAR)
             width, height = self._border_image.size
             if self._displayable:
                 self._image_widget.replace_border_image(


### PR DESCRIPTION
Previously the border image was always resized to the source image's
size, but now it should take the dimensions of the entire adjusted
image

[endlessm/eos-photos#188]
