### PR TITLE
Look for translatable files only in src/

### DIFF
--- a/generate_pot_file.sh
+++ b/generate_pot_file.sh
@@ -1,1 +1,1 @@
-find . -type f \( -name "*.py" -o -name "*.glade" \) | xargs xgettext --sort-output --keyword=N_ --keyword=C_:1c,2 -o po/endless_photos.pot --from-code=utf-8 --copyright-holder='Endless Mobile' --package-name='Endless Photos' --package-version=0
+find src -type f \( -name "*.py" -o -name "*.glade" \) | xargs xgettext --sort-output --keyword=N_ --keyword=C_:1c,2 -o po/endless_photos.pot --from-code=utf-8 --copyright-holder='Endless Mobile' --package-name='Endless Photos' --package-version=0


### PR DESCRIPTION
This was picking up strings that should not have been marked for
translation.

[endlessm/eos-photos#191]
