### PR TITLE
Several actions now cancel ongoing crops

### DIFF
--- a/src/photos_category_toolbars.py
+++ b/src/photos_category_toolbars.py
@@ -86,6 +86,9 @@ class TransformToolbar(CategoryToolbar):
 
         self.add(self._vbox)
 
+    def open_crop_options(self):
+        self._crop_button.show_crop_options()
+
     def close_crop_options(self):
         self._crop_button.hide_crop_options()
 
@@ -164,15 +167,12 @@ class CropOptions(Gtk.Frame):
 
     def apply_crop(self, event):
         self._presenter.on_crop_apply()
-        self.hide_crop_options()
 
     def activate_crop(self, event):
         self._presenter.on_crop_activate()
-        self.show_crop_options()
 
     def cancel_crop(self, event):
         self._presenter.on_crop_cancel()
-        self.hide_crop_options()
 
 class BlurToolbar(OptionListToolbar):
     def __init__(self, **kw):

--- a/src/photos_left_toolbar.py
+++ b/src/photos_left_toolbar.py
@@ -41,7 +41,7 @@ class PhotosLeftToolbar(Gtk.VBox):
         # current crop dimensions, if any)
         if category_label != "transform" and hasattr(self, '_presenter'):
             # do something to cancel crop
-            self._presenter.cancel_crop()
+            self._presenter.on_crop_cancel()
 
         for name, category in self._categories.items():
             if not name == category_label:

--- a/src/photos_model.py
+++ b/src/photos_model.py
@@ -281,13 +281,8 @@ class PhotosModel(object):
         self._update_base_image()
         self._update_border_image()
         
-    def disable_crop(self):
-        # Whenever the crop overlay is to be hidden, reapply all hidden effects,
-        # hide the UI for the overlay, and show the resulting image
-        if self._image_widget.crop_overlay_visible:
-            self.pop_options()
-            self._image_widget.hide_crop_overlay()
-            self._update_base_image()
+    def is_crop_active(self):
+        return self._image_widget.crop_overlay_visible
 
     def do_crop_activate(self):
         # Reset the crop coordinates, dropping any previous croppings


### PR DESCRIPTION
Saving, setting to background, sharing, reverting, and opening
images will all now cancel any crops which may be happening. Also
refactored the cancel-crop code path to be more sane/consistent

Also fixes #202 

[endlessm/eos-photos#199]
