### PR TITLE
Crop overlay is bound to size of image widget

### DIFF
--- a/src/crop_overlay.py
+++ b/src/crop_overlay.py
@@ -3,8 +3,6 @@ from draggable_box import DraggableBox
 
 class CropOverlay(Clutter.Actor):
     def __init__(self, **kw):
-        kw.setdefault('x-expand', True)
-        kw.setdefault('y-expand', True)
         kw["reactive"] = True
         super(CropOverlay, self).__init__(**kw)
 
@@ -16,8 +14,10 @@ class CropOverlay(Clutter.Actor):
     def hide_crop_overlay(self):
         self.hide()
 
-    def resize_crop_box(self, width, height):
-        self._crop_box.resize(width, height)
+    def resize_crop_box(self, stage_width, stage_height):
+        self.set_width(stage_width)
+        self.set_height(stage_height)
+        self._crop_box.resize(stage_width, stage_height)
 
     def get_crop_selection(self, width, height):
         return self._crop_box.get_crop_selection_coordinates(width, height)

--- a/src/draggable_box.py
+++ b/src/draggable_box.py
@@ -496,8 +496,8 @@ class DraggableHandle(DraggableOrnament):
         self.dimension = MARGIN
         self.current_knob = None
 
-        self.hitbox.set_height(MARGIN)
-        self.hitbox.set_width(MARGIN)
+        self.hitbox.set_height(self.dimension)
+        self.hitbox.set_width(self.dimension)
 
         NORMAL_KNOB_FILE_PATH = BASE_IMAGE_PATH + "crop_knob_normal.png"
         LIGHT_KNOB_FILE_PATH = BASE_IMAGE_PATH + "crop_knob_hover.png"


### PR DESCRIPTION
The crop overlay can no longer expand beyond the size of the image
widget, and is automatically resized whenever the widget's alloc
is changed. Resizes are still propagated down to the draggablebox

[endlessm/eos-photos#205]
