### PR TITLE
Cropbox now remembers its previous dimensions

### DIFF
--- a/src/crop_overlay.py
+++ b/src/crop_overlay.py
@@ -9,6 +9,7 @@ class CropOverlay(Clutter.Actor):
         self._crop_box = DraggableBox(self)
 
     def show_crop_overlay(self):
+        self._crop_box.resize(self.get_width(), self.get_height())
         self.show()
 
     def hide_crop_overlay(self):
@@ -27,3 +28,6 @@ class CropOverlay(Clutter.Actor):
 
     def get_crop_selection(self, width, height):
         return self._crop_box.get_crop_selection_coordinates(width, height)
+
+    def set_crop_selection(self, coordinates, width, height):
+        return self._crop_box.set_crop_selection_coordinates(coordinates, width, height)

--- a/src/photos_image_widget.py
+++ b/src/photos_image_widget.py
@@ -69,6 +69,9 @@ class PhotosImageWidget(Clutter.Actor):
         # reset the crop overlay to its default dimensions
         self._crop_overlay.reset_crop_box()
 
+    def set_crop_selection(self, coordinates, width, height):
+        self._crop_overlay.set_crop_selection(coordinates, width, height)
+
     def get_crop_selection(self, width, height):
         return self._crop_overlay.get_crop_selection(width, height)
 

--- a/src/photos_model.py
+++ b/src/photos_model.py
@@ -287,6 +287,27 @@ class PhotosModel(object):
         return self._image_widget.crop_overlay_visible
 
     def do_crop_activate(self):
+        # Crop overlay about to become visible, so resize it to the last crop selection.
+        # General strategy here is to set the cropbox's dimensions to the (potentially rotated)
+        # _last_crop_coordinates, and then perform the crop overlay's "rotate" operation as
+        # many times as is necessary to orient those dimensions to the current orientation.
+
+        width, height = self._source_image.size
+
+        # if the crop was made when the image was on its side, swap height and width
+        if self._crop_orientation in (90, 270):
+            width, height = height, width
+        self._image_widget.set_crop_selection(self._last_crop_coordinates, width, height)
+
+        # target_orientation = (degrees needed to rotate _crop_orientation to 0deg) + (current orientation)
+        un_orient_crop = 360 - self._crop_orientation
+        target_orientation = (un_orient_crop + self._orientation) % 360
+
+        # crop overlay's rotation operation works at 90 degree intervals (clockwise)
+        num_rotations = target_orientation / 90
+        for times in range(0, num_rotations):
+            self._image_widget.rotate_crop_overlay()
+
         # Reset the crop coordinates, dropping any previous croppings
         self._crop_coordinates = None
 


### PR DESCRIPTION
The box's dimensions are now stored as percentages of the total stage
area, and the box will retain its last set dimensions, even through
rotations/window resizes (i.e. if the cropbox covers the top right quadrant of the
image, and the image is rotated, the box will now be at the bottom right)

[endlessm/eos-photos#198]
