### PR TITLE
Fix photo app top bars

### DIFF
--- a/src/photos_window.py
+++ b/src/photos_window.py
@@ -17,10 +17,7 @@ class PhotosWindow(Endless.Window):
     allocated space.
     """
     def __init__(self, images_path="", splash_screen=None, left_toolbar=None, right_toolbar=None, image_container=None, **kw):
-        kw.setdefault('decorated', False)
-        kw.setdefault('window-position', Gtk.WindowPosition.CENTER)
-        kw.setdefault('has-resize-grip', False)
-        Gtk.Window.__init__(self, **kw)
+        Endless.Window.__init__(self, **kw)
         self._image_container = image_container
         self._splash_screen = splash_screen
         self._left_toolbar = left_toolbar


### PR DESCRIPTION
We now use Gtk's self decorated windows to do top bars. So we
should no longer set decorated to false. Also we were chaining
up to Gtk.Window init instead of Endless.Window init

[endlessm/eos-photos#225]
