### PR TITLE
New eos-photo package replaces old endlessos-base-photos

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,8 @@ Homepage: http://www.endlessm.com
 
 Package: eos-photos
 Architecture: all
+Replaces: endlessos-base-photos
+Breaks: endlessos-base-photos
 Depends: gir1.2-gtkclutter-1.0,
          gir1.2-clutter-1.0,
          gir1.2-endless-0,


### PR DESCRIPTION
So the two packages can't be installed at the same time.
[endlessm/eos-photos#222]
