### PR TITLE
Remove unnecessary build scripts.

### DIFF
--- a/install_fonts.sh
+++ b/install_fonts.sh
@@ -1,3 +1,0 @@
-# super simple for now, should check if this is the right approach
-sudo mkdir -p /usr/share/fonts/opentype/endless-os-photos
-sudo cp -r fonts/* /usr/share/fonts/opentype/endless-os-photos/

--- a/merge_pot_file_with_po_files.sh
+++ b/merge_pot_file_with_po_files.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -e
-
-for po_file in po/*.po
-do
-    echo "Merging $po_file"
-    msgmerge $po_file po/endless_photos.pot -o $po_file
-done


### PR DESCRIPTION
- install_fonts.sh - the fonts directory was removed in [00eefe8]
- merge_pot_file_with_po_files.sh - this functionality has been
  taken over by Transifex.

[endlessm/eos-photos#229]
