### PR TITLE
Rotated image now defaults to cropped image

### DIFF
--- a/src/photos_model.py
+++ b/src/photos_model.py
@@ -398,7 +398,7 @@ class PhotosModel(object):
         if self._crop_coordinates == None:
             self._cropped_image = self._source_image
         if self._orientation == 0:
-            self._rotated_image = self._source_image
+            self._rotated_image = self._cropped_image
 
         # If we need to crop, first rotate the image, then apply the crop, and then
         # rotate the cropped image back to 0 degrees. The image must first be rotated


### PR DESCRIPTION
This way, when no rotation occurs, the filter is applied to the
cropped image. Note that cropped image is always either the source image
(if the image isn't cropped) or the current crop selection

[endlessm/eos-photos#232]
