### PR TITLE
Pressing enter now applies crop

### DIFF
--- a/src/photos_category_toolbars.py
+++ b/src/photos_category_toolbars.py
@@ -158,6 +158,10 @@ class CropOptions(Gtk.Frame):
         self._style_context.add_class(self._options_state)
 
     def show_crop_options(self):
+        # Crop overlay is now visible, so a keypress to 'enter'
+        # should apply the crop
+        self._apply_button.grab_focus()
+
         self._crop_options_box.show()
         self._button_context.remove_class(self._options_state)
         self._style_context.remove_class(self._options_state)


### PR DESCRIPTION
There was a seeming bug where "clicked" signals were being emitted
when they shouldn't be for the crop buttons, so I switched them to
button-press-events instead.

[endlessm/eos-photos#234]
