### PR TITLE
Not entirely pleasant overrides to fix scrolled categories

### DIFF
--- a/src/widgets/toolbar_separator.py
+++ b/src/widgets/toolbar_separator.py
@@ -13,3 +13,16 @@ class ToolbarSeparator(Gtk.HBox):
         bottom_image = Gtk.Image.new_from_file(images_path + "separator_white.png")
         self._vbox.pack_start(bottom_image, expand=False, fill=False, padding=0)
         self.pack_start(self._vbox, expand=False, fill=False, padding=0)
+
+        self._is_visible = True
+
+        top_image.connect('draw', self._draw)
+        bottom_image.connect('draw', self._draw)
+
+    def set_visible(self, is_visible):
+        self._is_visible = is_visible
+
+    def _draw(self, w, cr):
+        # If the visible flag isn't set, do nothing during this draw cycle
+        if not self._is_visible:
+            return True


### PR DESCRIPTION
Hide the bottommost category's bottom separator whenever the left toolbar is too large for the window, rather than hiding the separator that's permanently above the revert button

[endlessm/eos-photos#243]
