### PR TITLE
Removed install file and custom rules

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,5 +1,0 @@
-data usr/share/eos-photos
-images usr/share/eos-photos
-src usr/share/eos-photos
-mo/* usr/share/locale
-eos-photos /usr/bin

--- a/debian/rules
+++ b/debian/rules
@@ -11,9 +11,3 @@
 
 %:
 	dh $@
-
-override_dh_install:
-	python generate_filter_thumbnails.py
-	find src -name '*.pyc' -delete
-	./build_mo_from_po_files.sh
-	dh_install


### PR DESCRIPTION
Now that we are on autotools for the photo app, we can just use
the standard rules which will run make install for us
[endlessm/eos-sdk#568]
