### PR TITLE
Create the data dir before creating endless_photos.gresource

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ CLEANFILES += data/images/thumbnails/thumbnails.gresource $(thumbnail_resource_f
 # static assets GResource file
 asset_resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/data --generate-dependencies $(srcdir)/data/endless_photos.gresource.xml)
 data/endless_photos.gresource: data/endless_photos.gresource.xml $(asset_resource_files)
+	mkdir -p data
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/data  $<
 CLEANFILES += data/endless_photos.gresource
 


### PR DESCRIPTION
One of build rules would sometimes try to write to a directory
before it existed when running with multithreaded make

[endlessm/eos-sdk#590]
