### PR TITLE
Use correct package name in gettext initialization

### DIFF
--- a/src/endless_photos.py
+++ b/src/endless_photos.py
@@ -4,7 +4,7 @@ import inspect
 from gi.repository import Gtk, Gdk, GLib, GtkClutter, GObject, Gio, Endless
 
 import gettext
-gettext.install('endless_photos')
+gettext.install('eos-photos')
 
 from photos_model import PhotosModel
 from photos_view import PhotosView


### PR DESCRIPTION
Our potfile name changed to agree with the eos-photos package name
as per convention. But we were still initing gettext with the old
endless_photos name in the python code, breaking translations.
[endlessm/eos-sdk#717]
