### PR TITLE
Added metadata (AppId, AppName, and MinOsVersion) to the packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,9 @@ Homepage: http://www.endlessm.com
 
 Package: eos-photos
 Architecture: all
+XCBS-EOS-MinOsVersion: 1.4.7
+XCBS-EOS-AppId: com.endlessm.photos
+XCBS-EOS-AppName: Photos
 Replaces: endlessos-base-photos
 Breaks: endlessos-base-photos
 Depends: gir1.2-gtkclutter-1.0,

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,0 +1,1 @@
+eos-photos *: */control' contains user-defined field *


### PR DESCRIPTION
  This will allow our deb2bundle and publisher script to have a full
  end-to-end push of the metadata that the update server needs to
  know about.

[endlessm/eos-shell#2388]
