### PR TITLE
Added shadow and moved arrows for expanding menus

### DIFF
--- a/data/endless_photos.css
+++ b/data/endless_photos.css
@@ -404,12 +404,11 @@ EosPageManager .image-frame {
     background-image: url("images/icon_topbar_OpenPhoto_normal.png");
 }
 
-/*.filters-scroll-area {
+.filters-scroll-area {
     background-image: -gtk-gradient (linear, left top, right top,
-                                     color-stop(0.0, alpha(#ffffff, 0.04)),
-                                     color-stop(0.8, alpha(#ffffff, 0.02)),
-                                     color-stop(1.0, alpha(#ffffff, 0.0)));
-}*/
+                                     color-stop(0.0, alpha(black, 0.2)),
+                                     color-stop(0.8, alpha(black, 0.0)));
+}
 
 .filters-scroll-area > GtkViewport {
     background-color: transparent;

--- a/src/photos_left_toolbar.py
+++ b/src/photos_left_toolbar.py
@@ -124,9 +124,9 @@ class CategoryButton(Gtk.Button, CompositeButton):
         self._arrow_align.add(self._arrow_frame)
 
         self._hbox = Gtk.HBox(homogeneous=False, spacing=0, margin_top=8, margin_bottom=8)
-        self._hbox.pack_start(self._icon_align, expand=False, fill=False, padding=9)
-        self._hbox.pack_start(self._category_label, expand=False, fill=False, padding=0)
-        self._hbox.pack_end(self._arrow_align, expand=False, fill=False, padding=8)
+        self._hbox.pack_start(self._arrow_align, expand=False, fill=False, padding=0)
+        self._hbox.pack_start(self._icon_align, expand=False, fill=False, padding=2)
+        self._hbox.pack_start(self._category_label, expand=False, fill=False, padding=10)
         # This hackish line keeps the expander widget from downsizing
         # horizontally after the separator is removed. 183 is the width of the
         # separator image


### PR DESCRIPTION
Arrows for the expanding filters menus were moved to the left side
of the menu. Shadow was added to the background of expanded menus
to match new design specs.

[endlessm/eos-sdk#1245]
