### PR TITLE
Added locale dir to get translations working

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,8 +44,10 @@ data/images/thumbnails/thumbnails.gresource: data/images/thumbnails/thumbnails.g
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=data/images/thumbnails  $<
 CLEANFILES += data/images/thumbnails/thumbnails.gresource $(thumbnail_resource_files)
 
-subst_install = sed -e 's|@pkgdatadir[@]|$(pkgdatadir)|g'
-subst_local = sed -e 's|@pkgdatadir[@]|$(realpath $(dir $(lastword $(MAKEFILE_LIST))))|g'
+subst_install = sed -e 's|@pkgdatadir[@]|$(pkgdatadir)|g' \
+	-e 's|@datadir[@]|$(datadir)|g'
+subst_local = sed -e 's|@pkgdatadir[@]|$(realpath $(dir $(lastword $(MAKEFILE_LIST))))|g' \
+	-e 's|@datadir[@]|$(datadir)|g'
 eos-photos: eos-photos.in Makefile
 	$(AM_V_GEN) $(subst_install) $< > $@
 	chmod +x $@

--- a/eos-photos.in
+++ b/eos-photos.in
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 
+import gettext
 import sys
-sys.path.append('@pkgdatadir@')
+pkg_dir = '@pkgdatadir@'
+data_dir = '@datadir@'
+locale_dir = data_dir + '/locale'
+
+sys.path.append(pkg_dir)
+gettext.install('eos-photos', locale_dir)
+
 from src.endless_photos import EndlessPhotos
 from gi.repository import GtkClutter, GLib, Gdk
 

--- a/src/endless_photos.py
+++ b/src/endless_photos.py
@@ -3,9 +3,6 @@ import os
 import inspect
 from gi.repository import Gtk, Gdk, GLib, GtkClutter, GObject, Gio, Endless
 
-import gettext
-gettext.install('eos-photos')
-
 from photos_model import PhotosModel
 from photos_view import PhotosView
 from photos_presenter import PhotosPresenter


### PR DESCRIPTION
Translations were not working at all on photos app because there
was not a locale dir being generated. Added a generated one.

After this is merged, this should be tested on an actual install as well (`sudo apt-get`).
[endlessm/eos-sdk#1543]
