### PR TITLE
Give window a title

### DIFF
--- a/src/photos_view.py
+++ b/src/photos_view.py
@@ -34,6 +34,7 @@ class PhotosView(object):
                                     left_toolbar=self._left_toolbar,
                                     right_toolbar=self._right_toolbar,
                                     image_container=self._image_container,
+                                    title=_("Photos"),
                                     application=application)
 
     def set_presenter(self, presenter):


### PR DESCRIPTION
If the window doesn't have a title, then the app ID shows up on the
desktop overview.

[endlessm/eos-shell#3383]
