### PR TITLE
Remove extra padding for open photo and revert photo buttons

### DIFF
--- a/src/photos_right_toolbar.py
+++ b/src/photos_right_toolbar.py
@@ -15,7 +15,7 @@ class PhotosRightToolbar(Gtk.VBox):
             image_size_y=ImageTextButton.SIZE_MEDIUM,
             halign=Gtk.Align.CENTER,
             margin_top=40,
-            margin_bottom=25, # preserves spacing in small windows
+            margin_bottom=15,
             label=_("OPEN PHOTO"),
             name="open-photo-button",
             vertical=True)
@@ -54,7 +54,7 @@ class PhotosRightToolbar(Gtk.VBox):
             image_size_x=ImageTextButton.SIZE_MEDIUM,
             image_size_y=ImageTextButton.SIZE_MEDIUM,
             halign=Gtk.Align.CENTER,
-            margin_top=25, # preserves spacing in small windows
+            margin_top=15,
             margin_bottom=40,
             label=_("REVERT IMAGE"),
             name="revert-image-button",


### PR DESCRIPTION
We have a bit of extra space between these two buttons to make
them stand out from the middle three even at small resolutions.
At my request originally I think. However this is barely bumping
us over the minimum vertical size we need to support for 800x600
so for now, ditch the extra padding.

[endlessm/eos-sdk#2200]
