### PR TITLE
Increase min OS version to 2.4.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Homepage: http://www.endlessm.com
 
 Package: eos-photos
 Architecture: all
-XCBS-EOS-MinOsVersion: 1.4.7
+XCBS-EOS-MinOsVersion: 2.4.0
 XCBS-EOS-AppId: com.endlessm.photos
 XCBS-EOS-AppName: Photos
 Replaces: endlessos-base-photos


### PR DESCRIPTION
This is required because the photo app uses the overlay pass-through
functionality from the version of GTK that we shipped in Endless 2.4.

[endlessm/eos-sdk#3419]
