### PR TITLE
photos_left_toolbar: change style class name

### DIFF
--- a/data/endless_photos.css
+++ b/data/endless_photos.css
@@ -82,14 +82,14 @@ EosPageManager .image-frame {
     background-image: url("images/icon_arrow_down.png");
 }
 
-.category-expander .label {
+.category-expander .category-label {
     font-size: 12px;
     color: #999999;
 }
 
-.category-expander .label:active,
-.category-expander .label:hover,
-.category-expander.expanded .label {
+.category-expander .category-label:active,
+.category-expander .category-label:hover,
+.category-expander.expanded .category-label {
     color: #ffffff;
 }
 

--- a/src/photos_left_toolbar.py
+++ b/src/photos_left_toolbar.py
@@ -90,7 +90,7 @@ class CategoryButton(Gtk.Button, CompositeButton):
         self._icon_align.add(self._icon_frame)
 
         self._category_label = Gtk.Label(label=category_label, name="category-label")
-        self._category_label.get_style_context().add_class("label")
+        self._category_label.get_style_context().add_class("category-label")
 
         self._arrow_frame = Gtk.Frame(halign=Gtk.Align.END)
         self._arrow_frame.get_style_context().add_class("arrow-frame")


### PR DESCRIPTION
We were using the style class "label" which is applied to all gtk
labels, to try to uniquely refer to a label in our category expanders.

I believe as part of the gtk update, styling meant only for the
expanders started applying to buttons inside the expanders.

Switch to a unique style class name to avoid the collision
[endlessm/eos-sdk#3466]
