### PR TITLE
theme: fix dialog rounded corners

### DIFF
--- a/data/endless_photos.css
+++ b/data/endless_photos.css
@@ -428,9 +428,7 @@ GtkScale {
     box-shadow: inset 0 -1px alpha(#ffffff, 0.25);
 }
 
-#message-box,
-FacebookAuthDialog,
-#message-dialog {
+#message-box {
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;   
 }


### PR DESCRIPTION
The confirm/deny dialogs and facebook auth dialogs no longer have a
top bar, so they should not round the bottom corners to match

The facebook message dialog does have a top bar, so it still needs
the rounded corners
[endlessm/eos-sdk#3482]
