### PR TITLE
T11249

### DIFF
--- a/src/photos_presenter.py
+++ b/src/photos_presenter.py
@@ -183,7 +183,8 @@ class PhotosPresenter(object):
 
     def _do_crop_activate(self):
         self._model.do_crop_activate()
-        self._view._transformations.open_crop_options()
+        # Defer showing crop options to avoid crashing the app
+        GLib.idle_add(self._view._transformations.open_crop_options)
 
     def _do_crop_apply(self):
         self._model.do_crop_apply()


### PR DESCRIPTION
photos_presenter: defer showing crop options

The photos app some times crashes while opening an image and
then clicking on the transform->crop option. This is hard to
reproduce, approximately 1 in 20 attemps of:
1. run eos-photos ~/path/to/image_file
2. click on transforms.
3. click on crop.

I could not find the exact reason why this happens, but noticed
during my tests that the issue seems to decrease in frequency
when things were slown down while updating the crop options css
styles, to the point where it can be avoided if deferred from
the crop overlay creation.

This workaround defers showing the crop options and avoids the
crash.

With this patch the app does not crash on several consecutive
tests (more than 40). Without this patch, the app crashes on less
than 20 tests.

https://phabricator.endlessm.com/T11249
