### PR TITLE
Adjust splash label size for composite

### DIFF
--- a/data/endless_photos.css
+++ b/data/endless_photos.css
@@ -506,3 +506,7 @@ GtkScale {
 .composite #revert-image-button GtkLabel {
     font-size: 6px;
 }
+
+.composite #splash-label {
+    font-size: 32px;
+}


### PR DESCRIPTION
The splash label was still too large for composite 720x480 when testing
with font scaling set to 1.25 as I should have all along.

https://phabricator.endlessm.com/T11401
