### PR TITLE
Revert "photos_presenter: defer showing crop options (#298)"

### DIFF
--- a/src/photos_presenter.py
+++ b/src/photos_presenter.py
@@ -183,8 +183,7 @@ class PhotosPresenter(object):
 
     def _do_crop_activate(self):
         self._model.do_crop_activate()
-        # Defer showing crop options to avoid crashing the app
-        GLib.idle_add(self._view._transformations.open_crop_options)
+        self._view._transformations.open_crop_options()
 
     def _do_crop_apply(self):
         self._model.do_crop_apply()


### PR DESCRIPTION
This reverts commit c78f9756b87f70c970c783c8c67447b9bf832fd2.

The workaround introduced by this commits does not seems to be needed anymore

https://phabricator.endlessm.com/T11249
