### PR TITLE
Use AM_PO_SUBDIRS instead of AM_GNU_GETTEXT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,8 +41,7 @@ AC_PROG_MKDIR_P
 # Library configuration tool
 PKG_PROG_PKG_CONFIG
 # Gettext
-AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.18.1])
+AM_PO_SUBDIRS
 # Various tools
 GLIB_GSETTINGS
 GLIB_COMPILE_RESOURCES=`$PKG_CONFIG --variable glib_compile_resources gio-2.0`


### PR DESCRIPTION
We aren't using a C compiler, so no need to check for C functions.

https://phabricator.endlessm.com/T14822