### PR TITLE
Fix the build on Fedora 24

### DIFF
--- a/src/image_processing/image_tools.py
+++ b/src/image_processing/image_tools.py
@@ -122,12 +122,12 @@ def _tilt_shift_mask(angle, rot_angle, (height, width), center_pct, amplitude):
         raw = l_slope * y + l_intercept
         raw = (raw / l_max) * amplitude
         normalized = raw if raw < 255 else 255
-        draw.point((0,y), normalized)
+        draw.point((0,y), int(normalized))
     for y in range(c,height):
         raw = r_slope * y + r_intercept
         raw = (raw / r_max) * amplitude
         normalized = raw if raw < 255 else 255
-        draw.point((0,y), normalized)
+        draw.point((0,y), int(normalized))
 
     return mask
 


### PR DESCRIPTION
The build fails with python-pillow-3.2.0 on Fedora 24:

Traceback (most recent call last):
  File "./generate-filter-thumbnails", line 74, in <module>
    model.set_blur(d)
  File "/home/rishi/devel/endlessm/git/eos-photos/src/photos_model.py", line 351, in set_blur
    self._update_base_image()
  File "/home/rishi/devel/endlessm/git/eos-photos/src/photos_model.py", line 442, in _update_base_image
    self._blurred_image = self._blur_dict[self._blur_type](self._distorted_image)
  File "/home/rishi/devel/endlessm/git/eos-photos/src/photos_model.py", line 65, in <lambda>
    (_("Tilt Shift"), lambda im: ImageTools.tilt_shift_blur(im)),
  File "/home/rishi/devel/endlessm/git/eos-photos/src/image_processing/image_tools.py", line 135, in tilt_shift_blur
    mask = _tilt_shift_mask(30.0, 90.0, image.size, 0.5, 350)
  File "/home/rishi/devel/endlessm/git/eos-photos/src/image_processing/image_tools.py", line 125, in _tilt_shift_mask
    draw.point((0,y), normalized)
  File "/usr/lib64/python2.7/site-packages/PIL/ImageDraw.py", line 207, in point
    ink, fill = self._getink(fill)
  File "/usr/lib64/python2.7/site-packages/PIL/ImageDraw.py", line 125, in _getink
    ink = self.draw.draw_ink(ink, self.mode)
SystemError: new style getargs format but argument is not a tuple
Makefile:1036: recipe for target 'data/images/thumbnails/thumbnails.gresource.xml' failed
make[1]: *** [data/images/thumbnails/thumbnails.gresource.xml] Error 1