### PR TITLE
Silence a deprecation warning on Fedora 24

### DIFF
--- a/src/image_processing/distortions.py
+++ b/src/image_processing/distortions.py
@@ -58,27 +58,27 @@ class Distortion:
         if distort_name == "SWIRL":
             radius = max(shape[0], shape[1]) / 2
             result = swirl(self._image_array, center=(shape[1]/2, shape[0]/2), strength=5, 
-                radius=radius, order=1, mode='nearest')
+                radius=radius, order=1, mode='edge')
         elif distort_name == "FISH EYE LIGHT":
             warp_args['radius_func'] = lambda radius_d: self.fish_eye(0.3, radius_d)
             warp_args['zoom_factor'] = 1.6
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='edge')
         elif distort_name == "FISH EYE HEAVY":
             warp_args['radius_func'] = lambda radius_d: self.fish_eye(0.6, radius_d)
             warp_args['zoom_factor'] = 2.2
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='edge')
         elif distort_name == "BULGE":
             warp_args['radius_func'] = lambda radius_d: self.bulge(radius_d)
             warp_args['zoom_factor'] = 1.45
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='edge')
         elif distort_name == "PINCH LIGHT":
             warp_args['radius_func'] = lambda radius_d: self.pinch(0.8, radius_d)
             warp_args['zoom_factor'] = 1
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='edge')
         elif distort_name == "PINCH HEAVY":
             warp_args['radius_func'] = lambda radius_d: self.pinch(0.5, radius_d)
             warp_args['zoom_factor'] = 1
-            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='nearest')
+            result = warp(self._image_array, self.radius_distort, map_args=warp_args, mode='edge')
         else:
             result = self._image_array
 


### PR DESCRIPTION
Mode 'nearest' is now called 'edge'. So it leads to this when building
with python-pillow-3.2.0 on Fedora 24:

/usr/lib64/python2.7/site-packages/skimage/_shared/utils.py:174: skimage_deprecation: Mode 'nearest' has been renamed to 'edge'. Mode 'nearest' will be removed in a future release.
  "Mode 'nearest' has been renamed to 'edge'. Mode 'nearest' will be "