### PR TITLE
build: Add flatpak-builder manifest

### DIFF
--- a/com.endlessm.photos.json
+++ b/com.endlessm.photos.json
@@ -1,0 +1,163 @@
+{
+    "app-id": "com.endlessm.photos",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "eos-photos",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.gfortran-62"
+    ],
+    "finish-args": [
+        "--share=ipc", "--share=network",
+        "--socket=x11", "--socket=wayland",
+        "--device=dri",
+        "--filesystem=home",
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+     ],
+    "build-options": {
+	"append-path": "/usr/lib/sdk/gfortran-62/bin"
+    },
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/aclocal",
+        "/share/doc",
+        "/share/gir-1.0",
+        "*.la"
+    ],
+    "modules": [
+        {
+            "name": "gfortran",
+            "buildsystem": "simple",
+            "build-commands": [ "/usr/lib/sdk/gfortran-62/install.sh" ]
+        },
+        {
+            "name": "lapack",
+            "buildsystem": "cmake",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DBUILD_TESTING=OFF",
+                "-DCMAKE_Fortran_COMPILER=/usr/lib/sdk/gfortran-62/bin/gfortran",
+                "-DLAPACKE=ON",
+                "-DCBLAS=ON"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.netlib.org/lapack/lapack-3.8.0.tar.gz",
+                    "sha512": "17786cb7306fccdc9b4a242de7f64fc261ebe6a10b6ec55f519deb4cb673cb137e8742aa5698fd2dc52f1cd56d3bd116af3f593a01dcf6770c4dcc86c50b2a7f"
+                }
+            ],
+            "cleanup": [ "/lib/cmake" ]
+        },
+        {
+            "name": "python3-numpy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py build -j 0",
+                "python3 setup.py install --prefix=/app --root=/ --optimize=1"
+            ],
+            "build-options": {
+                "env": {
+                    "ATLAS": "None",
+                    "BLAS": "/app/lib",
+                    "LAPACK": "/app/lib"
+                }
+            },
+            "cleanup": [ "/bin" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/0b/66/86185402ee2d55865c675c06a5cfef742e39f4635a4ce1b1aefd20711c13/numpy-1.14.2.zip",
+                    "sha256": "facc6f925c3099ac01a1f03758100772560a0b020fb9d70f210404be08006bcb"
+                }
+            ]
+        },
+        {
+            "name": "python3-scipy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py build -j 0",
+                "python3 setup.py install --prefix=/app --root=/ --optimize=1"
+            ],
+            "build-options": {
+                "env": {
+                    "ATLAS": "None",
+                    "BLAS": "/app/lib",
+                    "LAPACK": "/app/lib",
+                    "LDFLAGS": "-shared"
+                }
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/bd/f4/3882758754dc083fea6ea66a6e8ceef55e7df173d06a12a074612958800f/scipy-1.0.1.tar.gz",
+                    "sha256": "8739c67842ed9a1c34c62d6cca6301d0ade40d50ef14ba292bd331f0d6c940ba"
+                }
+            ]
+        },
+        "python3-Pillow.json",
+        "python3-setuptools_scm.json",
+        "python3-six.json",
+        "python3-matplotlib.json",
+        "python3-networkx.json",
+        "python3-PyWavelets.json",
+        "python3-scikit-image.json",
+        "python3-dbus-python.json",
+        "python3-python-dbusmock.json",
+        "python3-requests.json",
+        {
+            "name": "eos-metrics",
+            "config-opts": [
+                "--disable-gtk-doc",
+                "--disable-gir-doc"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/endlessm/eos-metrics",
+                    "commit": "ab66c7319c573999740f636555b14b6f658e82c0"
+                }
+            ]
+        },
+        {
+            "name": "eos-sdk",
+            "build-options": {
+                "env": {
+                    "PYTHON": "python3"
+                },
+                "config-opts": [
+                    "--disable-gtk-doc",
+                    "--disable-gir-doc",
+                    "--disable-js-doc",
+                    "--disable-webhelper"
+                ]
+            },
+            "cleanup": [
+                "/bin",
+                "/libexec",
+                "/share/gjs-1.0"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/endlessm/eos-sdk",
+                    "commit": "90342f56a3dd5afa7825f00001562843eebcb749"
+                }
+            ]
+        },
+        {
+            "name": "eos-photos",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/endlessm/eos-photos",
+		    "tag": "1.0.1"
+                }
+            ]
+        }
+    ]
+}

--- a/python3-Pillow.json
+++ b/python3-Pillow.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-Pillow",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} Pillow"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/0f/57/25be1a4c2d487942c3ed360f6eee7f41c5b9196a09ca71c54d1a33c968d9/Pillow-5.0.0.tar.gz",
+            "sha256": "12f29d6c23424f704c66b5b68c02fe0b571504459605cfe36ab8158359b0e1bb"
+        }
+    ]
+}

--- a/python3-PyWavelets.json
+++ b/python3-PyWavelets.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-PyWavelets",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} PyWavelets"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/4b/df/3fff2a8b96ef7df6e4e8642fb7569c3717ae562dd76afe0f96525c0af784/PyWavelets-0.5.2.tar.gz",
+            "sha256": "ce36e2f0648ea1781490b09515363f1f64446b0eac524603e5db5e180113bed9"
+        }
+    ]
+}

--- a/python3-dbus-python.json
+++ b/python3-dbus-python.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-dbus-python",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} dbus-python"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/ad/1b/76adc363212c642cabbf9329457a918308c0b9b5d38ce04d541a67255174/dbus-python-1.2.4.tar.gz",
+            "sha256": "e2f1d6871f74fba23652e51d10873e54f71adab0525833c19bad9e99b1b2f9cc"
+        }
+    ]
+}

--- a/python3-matplotlib.json
+++ b/python3-matplotlib.json
@@ -1,0 +1,39 @@
+{
+    "name": "python3-matplotlib",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} matplotlib"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/31/60/494fcce70d60a598c32ee00e71542e52e27c978e5f8219fae0d4ac6e2864/kiwisolver-1.0.1.tar.gz",
+            "sha256": "ce3be5d520b4d2c3e5eeb4cd2ef62b9b9ab8ac6b6fedbaa0e39cdb6f50644278"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/1b/50/4cdc62fc0753595fc16c8f722a89740f487c6e5670c644eb8983946777be/pytz-2018.3.tar.gz",
+            "sha256": "410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/c5/39/4da7c2dbc4f023fba5fb2325febcadf0d0ce0efdc8bd12083a0f65d20653/python-dateutil-2.7.2.tar.gz",
+            "sha256": "9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/3c/ec/a94f8cf7274ea60b5413df054f82a8980523efd712ec55a59e7c3357cf7c/pyparsing-2.2.0.tar.gz",
+            "sha256": "0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/c2/4b/137dea450d6e1e3d474e1d873cd1d4f7d3beed7e0dc973b06e8e10d32488/cycler-0.10.0.tar.gz",
+            "sha256": "cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/ec/ed/46b835da53b7ed05bd4c6cae293f13ec26e877d2e490a53a709915a9dcb7/matplotlib-2.2.2.tar.gz",
+            "sha256": "4dc7ef528aad21f22be85e95725234c5178c0f938e2228ca76640e5e84d8cde8"
+        }
+    ]
+}

--- a/python3-networkx.json
+++ b/python3-networkx.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-networkx",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} networkx"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/70/f1/cb9373195639db13063f55eb06116310ad691e1fd125e6af057734dc44ea/decorator-4.2.1.tar.gz",
+            "sha256": "7d46dd9f3ea1cf5f06ee0e4e1277ae618cf48dfb10ada7c8427cd46c42702a0e"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/11/42/f951cc6838a4dff6ce57211c4d7f8444809ccbe2134179950301e5c4c83c/networkx-2.1.zip",
+            "sha256": "64272ca418972b70a196cb15d9c85a5a6041f09a2f32e0d30c0255f25d458bb1"
+        }
+    ]
+}

--- a/python3-python-dbusmock.json
+++ b/python3-python-dbusmock.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-python-dbusmock",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} python-dbusmock"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/4e/9b/cea7a005e6df6918932126a821d22119d12e6ed4ce29acf59a300d6fb3af/python-dbusmock-0.17.2.tar.gz",
+            "sha256": "b6876367206f9a7a97ebe5f0c50dd96e4534b6e1c22199b9314870dd72793895"
+        }
+    ]
+}

--- a/python3-requests.json
+++ b/python3-requests.json
@@ -1,0 +1,37 @@
+{
+    "name": "python3-requests",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} requests"
+    ],
+    "cleanup": [
+        "/bin"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/15/d4/2f888fc463d516ff7bf2379a4e9a552fef7f22a94147655d9b1097108248/certifi-2018.1.18.tar.gz",
+            "sha256": "edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz",
+            "sha256": "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/f4/bd/0467d62790828c23c47fc1dfa1b1f052b24efdf5290f071c7a91d0d82fd3/idna-2.6.tar.gz",
+            "sha256": "2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz",
+            "sha256": "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+        },
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz",
+            "sha256": "9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+        }
+    ]
+}

--- a/python3-scikit-image.json
+++ b/python3-scikit-image.json
@@ -1,0 +1,17 @@
+{
+    "name": "python3-scikit-image",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} scikit-image"
+    ],
+    "cleanup": [
+        "/bin"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/83/2a/c5a39c12c196c19a443fa4d17c0768a24231e46ae952930a9d66bad45557/scikit-image-0.13.1.tar.gz",
+            "sha256": "353879ddf7483f4621872c49cd9bc8a0ad1c3154ac0670b70799922f4cb899e8"
+        }
+    ]
+}

--- a/python3-setuptools_scm.json
+++ b/python3-setuptools_scm.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-setuptools_scm",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} setuptools_scm"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/a7/52/5f84da9ee2780682795550ddea20bec3e604a8a82600f4e5d3a6ca0bcbcd/setuptools_scm-1.17.0.tar.gz",
+            "sha256": "70a4cf5584e966ae92f54a764e6437af992ba42ac4bca7eb37cc5d02b98ec40a"
+        }
+    ]
+}

--- a/python3-six.json
+++ b/python3-six.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-six",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} six"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://pypi.python.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz",
+            "sha256": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+        }
+    ]
+}


### PR DESCRIPTION
This adds the flatpak-builder manifest and associated files currently
pending for Flathub on https://github.com/flathub/flathub/pull/356