### PR TITLE
gfortran: libquadmath is not available everywhere

### DIFF
--- a/flatpak/com.endlessm.photos.json
+++ b/flatpak/com.endlessm.photos.json
@@ -32,7 +32,11 @@
         {
             "name": "gfortran",
             "buildsystem": "simple",
-            "build-commands": [ "/usr/lib/sdk/gfortran-62/install.sh" ]
+            "build-commands": [
+                "mkdir -p /app/lib",
+                "if [ -e /usr/lib/sdk/gfortran-62/lib/libquadmath.so ]; then cp -P /usr/lib/sdk/gfortran-62/lib/libquadmath.so* /app/lib; fi",
+                "cp -P /usr/lib/sdk/gfortran-62/lib/libgfortran.so* /app/lib/"
+            ],
         },
         {
             "name": "lapack",


### PR DESCRIPTION
Only on Intel, so check if it exists before copying it over.
Temporarily copy the contents of install.sh until this is fixed
upstream; see
https://github.com/flatpak/freedesktop-sdk-images/pull/107