### PR TITLE
build: Upgrade Pillow

### DIFF
--- a/flatpak/python3-Pillow.json
+++ b/flatpak/python3-Pillow.json
@@ -2,13 +2,13 @@
     "name": "python3-Pillow",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} Pillow"
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} pillow"
     ],
     "sources": [
         {
             "type": "file",
-            "url": "https://pypi.python.org/packages/0f/57/25be1a4c2d487942c3ed360f6eee7f41c5b9196a09ca71c54d1a33c968d9/Pillow-5.0.0.tar.gz",
-            "sha256": "12f29d6c23424f704c66b5b68c02fe0b571504459605cfe36ab8158359b0e1bb"
+            "url": "https://files.pythonhosted.org/packages/89/b8/2f49bf71cbd0e9485bb36f72d438421b69b7356180695ae10bd4fd3066f5/Pillow-5.1.0.tar.gz",
+            "sha256": "cee9bc75bff455d317b6947081df0824a8f118de2786dc3d74a3503fd631f4ef"
         }
     ]
 }


### PR DESCRIPTION
Version 5.1.0 should have the commit
https://github.com/python-pillow/Pillow/commit/8edbc79e7f5cf32307caf609b1a346456f8d9fb4
which fixes a problem building on ARM.

https://phabricator.endlessm.com/T22632