### PR TITLE
Explicitly require GTK 3 to prevent GTK 4 from being loaded

### DIFF
--- a/src/endless_photos.py
+++ b/src/endless_photos.py
@@ -1,6 +1,8 @@
 import sys
 import os
 import inspect
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib, GtkClutter, GObject, Gio, Endless
 
 from .photos_model import PhotosModel


### PR DESCRIPTION
When GTK 4 is installed concurrently with GTK 3, importing Gtk will
result in GTK 4 being loaded. However, GTK 3 will be required later
by other dependencies, resulting in a conflict:

    Requiring namespace 'Gtk' version '3.0', but '4.0' is already loaded

To prevent this from happening, explicitly require GTK 3 until the app
is ported to support GTK 4.