### PR TITLE
Appstream improvements

### DIFF
--- a/data/com.endlessm.photos.appdata.xml
+++ b/data/com.endlessm.photos.appdata.xml
@@ -74,7 +74,11 @@
   <developer_name>Endless</developer_name>
 
   <translation type="gettext">eos-photos</translation>
-  <url type="homepage">http://www.endlessm.com</url>
+  <url type="homepage">https://endlessos.org/</url>
+  <url type="bugtracker">https://github.com/endlessm/eos-photos/issues</url>
+  <url type="translate">https://www.transifex.com/endless-os/eos-photos/</url>
+  <url type="vcs-browser">https://github.com/endlessm/eos-photos</url>
+
 
   <releases>
     <release date="2018-07-10" version="1.0.2"/>
@@ -111,5 +115,5 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
 
-  <update_contact>cosimo@endlessm.com</update_contact>
+  <update_contact>maintainers@endlessos.org</update_contact>
 </component>


### PR DESCRIPTION
Fixes #326 and adds some other bits.

`appstreamcli validate` is still not especially happy:

```
$ appstreamcli validate --explain --pedantic data/com.endlessm.photos.appdata.xml   
P: com.endlessm.photos.desktop:63: screenshot-no-caption
   The screenshot does not have a caption text. Consider adding one.

E: com.endlessm.photos.desktop:49: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:46: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:43: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:40: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

P: com.endlessm.photos.desktop:58: screenshot-no-caption
   The screenshot does not have a caption text. Consider adding one.

W: com.endlessm.photos.desktop:80: url-invalid-type vcs-browser
   Invalid `type` property for this `url` tag. URLs of this type are not known in the AppStream
   specification.

P: com.endlessm.photos.desktop:53: screenshot-no-caption
   The screenshot does not have a caption text. Consider adding one.

E: com.endlessm.photos.desktop:39: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:47: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:44: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:41: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

I: com.endlessm.photos.desktop:70: nonstandard-gnome-extension metadata
   This tag is a GNOME-specific extension to AppStream and not part of the official specification.
   Do not expect it to work in all implementations and in all software centers.

E: com.endlessm.photos.desktop:50: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:48: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:45: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

E: com.endlessm.photos.desktop:42: metainfo-localized-description-tag description
   A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the
   individual paragraphs instead.

Validation failed: errors: 12, warnings: 1, infos: 1, pedantic: 3
```

hey ho.

https://phabricator.endlessm.com/T33504