### PR TITLE
Require specific versions of gobject-introspection modules

### DIFF
--- a/src/draggable_box.py
+++ b/src/draggable_box.py
@@ -61,7 +61,7 @@ CURRENT_DIR = os.path.dirname(CURRENT_FILE)
 BASE_IMAGE_PATH = os.path.join(CURRENT_DIR, os.pardir) + '/data/images/'
 
 class DraggableBox(Clutter.Actor):
-    
+
     def __init__(self, stage, **kw):
         kw["opacity"] = 0
         kw["reactive"] = True
@@ -123,7 +123,7 @@ class DraggableBox(Clutter.Actor):
             self.height_as_pct = bot_coord / real_height - self.y_pos_as_pct
 
     def reset_dimensions(self):
-        # The box will store its position/dimensions as percentages of the total stage, 
+        # The box will store its position/dimensions as percentages of the total stage,
         # (values between 0 and 1) so that upon stage resizing/rotation, its dimensions
         # can be reconstructed faithfully
         self.x_pos_as_pct = (1 - DEFAULT_PROPORTION) / 2
@@ -362,9 +362,9 @@ class DraggableBox(Clutter.Actor):
 
             # All the boxes have their namesake's edge bound to the same
             # named edge of the stage, and have the opposite side bound to their
-            # namesake's edge of CROP. 
+            # namesake's edge of CROP.
             #
-            # For example, LEFT's left side is bound to the left edge of 
+            # For example, LEFT's left side is bound to the left edge of
             # the stage, and LEFT's right side is bound to the left side of CROP
 
             cropbox_constraint = Clutter.SnapConstraint()
@@ -498,7 +498,7 @@ class DraggableBox(Clutter.Actor):
             elif clicked_region & BOT:
                 self.set_height(self.get_height() + dy)
         else:
-            # If the click happened away from either horizontal or 
+            # If the click happened away from either horizontal or
             # vertical edges, just drag the box around
             self.set_x(self.get_x() + dx)
             self.set_y(self.get_y() + dy)
@@ -507,7 +507,7 @@ class DraggableOrnament(Clutter.Group):
     """
     Base class for an object which forwards mouse events to the crop box. The hitbox actor is kept
     separate from any other visual actors so that the ornament can receieve events over a wider
-    region than what is actually visible to the user 
+    region than what is actually visible to the user
     """
     def __init__(self, box, coordinate, **kw):
         kw["reactive"] = True

--- a/src/draggable_box.py
+++ b/src/draggable_box.py
@@ -1,6 +1,7 @@
 import os
 import inspect
-
+import gi
+gi.require_version("Gdk", "3.0")
 from gi.repository import Clutter, Gdk
 
 from . import util

--- a/src/drop_shadow_alignment.py
+++ b/src/drop_shadow_alignment.py
@@ -1,6 +1,8 @@
 import cairo
 import math
 
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk,Gdk
 
 class DropShadowAlignment(Gtk.Alignment):

--- a/src/drop_shadow_alignment.py
+++ b/src/drop_shadow_alignment.py
@@ -3,6 +3,7 @@ import math
 
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk,Gdk
 
 class DropShadowAlignment(Gtk.Alignment):

--- a/src/endless_photos.py
+++ b/src/endless_photos.py
@@ -3,6 +3,7 @@ import os
 import inspect
 import gi
 gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
 from gi.repository import Gtk, Gdk, GLib, GtkClutter, GObject, Gio, Endless
 
 from .photos_model import PhotosModel

--- a/src/endless_photos.py
+++ b/src/endless_photos.py
@@ -4,6 +4,8 @@ import inspect
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
+gi.require_version('GtkClutter', '1.0')
+gi.require_version('Endless', '0')
 from gi.repository import Gtk, Gdk, GLib, GtkClutter, GObject, Gio, Endless
 
 from .photos_model import PhotosModel

--- a/src/photos_category_toolbars.py
+++ b/src/photos_category_toolbars.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from .widgets.option_list import OptionList

--- a/src/photos_image_container.py
+++ b/src/photos_image_container.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import GtkClutter, Clutter
 
 

--- a/src/photos_image_widget.py
+++ b/src/photos_image_widget.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gdk", "3.0")
 from gi.repository import Clutter, GLib, Gdk, GObject
 
 from .crop_overlay import CropOverlay

--- a/src/photos_image_widget.py
+++ b/src/photos_image_widget.py
@@ -46,7 +46,7 @@ class PhotosImageWidget(Clutter.Actor):
             return self._ratio
         else:
             return Clutter.Actor.do_get_property(self, property)
-    
+
     def toggle_crop_overlay(self):
         if self.crop_overlay_visible:
             self.hide_crop_overlay()

--- a/src/photos_left_toolbar.py
+++ b/src/photos_left_toolbar.py
@@ -2,6 +2,7 @@ import collections
 import cairo
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf
 
 from .widgets.composite_button import CompositeButton

--- a/src/photos_left_toolbar.py
+++ b/src/photos_left_toolbar.py
@@ -1,5 +1,7 @@
 import collections
 import cairo
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf
 
 from .widgets.composite_button import CompositeButton

--- a/src/photos_presenter.py
+++ b/src/photos_presenter.py
@@ -4,6 +4,8 @@ import os
 import tempfile
 import urllib.request, urllib.error, urllib.parse
 import time
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk, Gio
 
 from .asyncworker import AsyncWorker

--- a/src/photos_right_toolbar.py
+++ b/src/photos_right_toolbar.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Endless, Gtk, Gio
 
 from .widgets.image_text_button import ImageTextButton

--- a/src/photos_view.py
+++ b/src/photos_view.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GLib
 
 from .splash_screen import SplashScreen

--- a/src/photos_view.py
+++ b/src/photos_view.py
@@ -1,5 +1,6 @@
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk, GLib
 
 from .splash_screen import SplashScreen

--- a/src/photos_window.py
+++ b/src/photos_window.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf, Endless
 
 from .drop_shadow_alignment import DropShadowAlignment

--- a/src/photos_window.py
+++ b/src/photos_window.py
@@ -1,5 +1,6 @@
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf, Endless
 
 from .drop_shadow_alignment import DropShadowAlignment

--- a/src/share/facebook_auth_dialog.py
+++ b/src/share/facebook_auth_dialog.py
@@ -1,6 +1,10 @@
 import urllib.request, urllib.parse, urllib.error
 import gi
 gi.require_version("Gtk", "3.0")
+try:
+    gi.require_version('WebKit2', '4.1')
+except ValueError:
+    gi.require_version('WebKit2', '4.0')
 from gi.repository import Gtk, WebKit2
 
 

--- a/src/share/facebook_auth_dialog.py
+++ b/src/share/facebook_auth_dialog.py
@@ -1,4 +1,6 @@
 import urllib.request, urllib.parse, urllib.error
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, WebKit2
 
 

--- a/src/splash_screen.py
+++ b/src/splash_screen.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from .widgets.image_text_button import ImageTextButton

--- a/src/util.py
+++ b/src/util.py
@@ -1,6 +1,8 @@
 
 from PIL import Image
 import io
+import gi
+gi.require_version("Gdk", "3.0")
 from gi.repository import Clutter, Cogl, GdkPixbuf, Gio
 
 def load_clutter_image_from_resource(resource_path):

--- a/src/widgets/composite_button.py
+++ b/src/widgets/composite_button.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 

--- a/src/widgets/composite_button.py
+++ b/src/widgets/composite_button.py
@@ -37,8 +37,7 @@ class CompositeButton(object):
                 # for each flag we want the children to inherit, grab this widget's flag
                 # value, and set the child's matching flag accordingly
                 my_flag = int(my_flags & flag)
-                set_value = (my_flag is not 0)
-                if set_value:
+                if my_flag != 0:
                     child.set_state_flags(flag, True)
                 else:
                     child.unset_state_flags(flag)

--- a/src/widgets/image_text_button.py
+++ b/src/widgets/image_text_button.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf, Gdk
 from .composite_button import CompositeButton
 

--- a/src/widgets/image_text_button.py
+++ b/src/widgets/image_text_button.py
@@ -1,5 +1,6 @@
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, GdkPixbuf, Gdk
 from .composite_button import CompositeButton
 

--- a/src/widgets/option_list.py
+++ b/src/widgets/option_list.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from .composite_button import CompositeButton

--- a/src/widgets/preview_file_chooser_dialog.py
+++ b/src/widgets/preview_file_chooser_dialog.py
@@ -1,4 +1,6 @@
 import os
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf
 
 

--- a/src/widgets/preview_file_chooser_dialog.py
+++ b/src/widgets/preview_file_chooser_dialog.py
@@ -1,6 +1,7 @@
 import os
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf
 
 

--- a/src/widgets/slider.py
+++ b/src/widgets/slider.py
@@ -4,7 +4,7 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk
 
 class Slider(Gtk.HScale):
-    
+
     SNAP_MARGIN = 0.1
 
     def __init__(self, adjustment=None, **kw):
@@ -16,7 +16,7 @@ class Slider(Gtk.HScale):
         self.DEFAULT_VALUE = adjustment.get_value()
 
         self.connect('button-press-event', self._detect_double_click)
-    
+
     # Override default button-release event, so when
     # user releases the mouse after a double click, the
     # value is set to the default value rather than
@@ -28,7 +28,7 @@ class Slider(Gtk.HScale):
             self.set_value(self.DEFAULT_VALUE)
 
     def do_value_changed(self, **kw):
-        current_val = self.get_adjustment().get_value() 
+        current_val = self.get_adjustment().get_value()
         dist_to_default = abs(current_val - self.DEFAULT_VALUE)
         if dist_to_default < self.SNAP_MARGIN:
             self.set_value(self.DEFAULT_VALUE)

--- a/src/widgets/slider.py
+++ b/src/widgets/slider.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 
 class Slider(Gtk.HScale):

--- a/src/widgets/slider.py
+++ b/src/widgets/slider.py
@@ -1,5 +1,6 @@
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk
 
 class Slider(Gtk.HScale):

--- a/src/widgets/text_entry.py
+++ b/src/widgets/text_entry.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 
 

--- a/src/widgets/text_entry.py
+++ b/src/widgets/text_entry.py
@@ -1,5 +1,6 @@
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk
 
 


### PR DESCRIPTION
This is necessary when the runtime includes (for example) both GTK 3 and GTK 4.